### PR TITLE
Fix typo in Tailwind class causing build error

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,7 +53,7 @@
   }
 
   .body-container {
-    @apply sm:mb-4 mb:10;
+    @apply sm:mb-4 mb-10;
   }
 
   .products-container {


### PR DESCRIPTION
- Corrected incorrect class `mb:10` to `mb-10`
- Fixed build error caused by invalid Tailwind syntax